### PR TITLE
Fix contacts error handling

### DIFF
--- a/scripts/manual-check-post.js
+++ b/scripts/manual-check-post.js
@@ -1,0 +1,19 @@
+// Manual check script for server/api/contacts.post.js error handling
+async function test() {
+    let contacts;
+    try {
+        // simulate readBody throwing
+        throw new Error('Read body failed');
+    } catch (error) {
+        console.error('Fehler beim Upserten der Kontakte:', error);
+        const documents = Array.isArray(contacts)
+            ? contacts.map((contact) => ({
+                  ...contact,
+                  $id: contact.$id || `demo-${Date.now()}`,
+              }))
+            : [];
+        console.log('documents length:', documents.length);
+    }
+}
+
+await test();

--- a/server/api/contacts.post.js
+++ b/server/api/contacts.post.js
@@ -1,8 +1,9 @@
 import { db } from "~/server/utils/appwrite";
 
 export default defineEventHandler(async (event) => {
+    let contacts;
     try {
-        const { contacts } = await readBody(event);
+        ({ contacts } = await readBody(event));
         const response = await db.upsertDocuments(contacts);
         return response;
     } catch (error) {
@@ -10,13 +11,16 @@ export default defineEventHandler(async (event) => {
 
         // Simulation für Entwicklung
         console.log("Simuliere Speichern für Entwicklung...");
+        const documents = Array.isArray(contacts)
+            ? contacts.map((contact) => ({
+                  ...contact,
+                  $id: contact.$id || `demo-${Date.now()}`,
+              }))
+            : [];
         return {
             success: true,
             message: "Kontakte erfolgreich gespeichert (Demo-Modus)",
-            documents: contacts.map((contact) => ({
-                ...contact,
-                $id: contact.$id || `demo-${Date.now()}`,
-            })),
+            documents,
         };
     }
 });


### PR DESCRIPTION
## Summary
- avoid ReferenceError by defining `contacts` before the try block
- return demo documents only when contacts exist
- add manual script demonstrating catch block behavior

## Testing
- `node scripts/manual-check-post.js`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68686b9b991083339dfe3cc83e424663